### PR TITLE
Fixes auto-mutes in Reels

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Video Control for Instagram",
-  "version": "0.3",
+  "version": "0.4",
 
   "description": "Adds volume and play controls to Instagram videos.",
   "author": "mail@david-schulte.de",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Video Control for Instagram",
-  "version": "0.3",
+  "version": "0.4",
 
   "description": "Adds volume and play controls to Instagram videos.",
   "author": "mail@david-schulte.de",


### PR DESCRIPTION
There was an issue where Instagram would mute the next video in Reels. The script interpreted this as a legit user interaction and kept the videos on mute. 
I couldn't figure out how to detect these volume events. My solution is to ignore all volume events for 10ms after a video was started. This isn't the cleanest solution, but it fixes the issue.

Also sets the version to 0.4.