### PR TITLE
Enable support for embedded Instagram videos

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Video Control for Instagram",
-  "version": "0.4",
+  "version": "0.5",
 
   "description": "Adds volume and play controls to Instagram videos.",
   "author": "mail@david-schulte.de",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -15,7 +15,8 @@
   "content_scripts": [
     {
       "matches": ["*://*.instagram.com/*"],
-      "js": ["main.js"]
+      "js": ["main.js"],
+      "all_frames": true
     }
   ]
 }

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Video Control for Instagram",
-  "version": "0.4",
+  "version": "0.5",
 
   "description": "Adds volume and play controls to Instagram videos.",
   "author": "mail@david-schulte.de",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -15,7 +15,8 @@
   "content_scripts": [
     {
       "matches": ["*://*.instagram.com/*"],
-      "js": ["main.js"]
+      "js": ["main.js"],
+      "all_frames": true
     }
   ]
 }


### PR DESCRIPTION
This allows the extension to enable controls on embedded Instagram videos on other websites.
It will also allow to re-watch a video once it was played in the embedded frame. Normally Instagram forces the user to open the post on the main site to open it.