### PR TITLE
Reverted combined build pipeline and Firefox MV3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,9 +44,12 @@ jobs:
           name: release_url
           path: ./release_url.txt
 
-  # Publish
+  # Publish all version
   publish:
     name: Publish
+    strategy:
+      matrix:
+        target: [ 'firefox', 'chrome' ]
     runs-on: ubuntu-latest
     needs: [ release ]
 
@@ -74,18 +77,18 @@ jobs:
 
       # Clean the output folder
       - name: Clean
-        run: rm -rf ./release.zip ./release
+        run: rm -rf ./release-${{ matrix.target }}.zip ./release-${{ matrix.target }}
 
       # Copy files
       - name: Copy files
         run: |
-          mkdir ./release &&
-          cp -r ./content/* ./release &&
-          cp -r ./manifest.json ./release
+          mkdir ./release-${{ matrix.target }} &&
+          cp -r ./content/* ./release-${{ matrix.target }} &&
+          cp -r ./${{ matrix.target }}/* ./release-${{ matrix.target }}
 
       # Create a .zip archive
       - name: Packing archive
-        run: cd ./release && zip -r ../release.zip * && cd ..
+        run: cd ./release-${{ matrix.target }} && zip -r ../release-${{ matrix.target }}.zip * && cd ..
 
       # Upload the release
       - name: Upload release
@@ -95,6 +98,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-          asset_path: ./release.zip
-          asset_name: ${{ steps.get_release_info.outputs.file_name }}.zip
+          asset_path: ./release-${{ matrix.target }}.zip
+          asset_name: ${{ steps.get_release_info.outputs.file_name }}-${{ matrix.target }}.zip
           asset_content_type: application/zip

--- a/build.sh
+++ b/build.sh
@@ -2,12 +2,15 @@
 rm -rf ./build
 
 # Create target directories
-mkdir ./build
+mkdir ./build && mkdir ./build/chrome && mkdir ./build/firefox
 
 # Copy main content
-cp -r ./content/* ./build
+cp -r ./content/* ./build/chrome
+cp -r ./content/* ./build/firefox
 
-# Copy manifest
-cp -r ./manifest.json ./build
+# Copy manifests
+cp -r ./chrome/* ./build/chrome
+cp -r ./firefox/* ./build/firefox
 
-cd ./build && zip -r plugin.zip * && cd -
+cd ./build/chrome && zip -r plugin.zip * && cd -
+cd ./build/firefox && zip -r plugin.zip * && cd -

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 3,
+  "name": "Video Control for Instagram",
+  "version": "0.6",
+
+  "description": "Adds volume and play controls to Instagram videos.",
+  "author": "mail@david-schulte.de",
+  "homepage_url": "https://github.com/Arcus92/instagram-video-control/",
+
+  "icons": {
+    "48": "icons/icon-48.png",
+    "64": "icons/icon-64.png",
+    "128": "icons/icon-128.png"
+  },
+  "content_scripts": [
+    {
+      "matches": ["*://*.instagram.com/*"],
+      "js": ["main.js"],
+      "all_frames": true
+    }
+  ],
+  "permissions": ["storage"]
+}

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Video Control for Instagram",
-  "version": "0.6",
+  "version": "0.7",
 
   "description": "Adds volume and play controls to Instagram videos.",
   "author": "mail@david-schulte.de",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 3,
+  "manifest_version": 2,
   "name": "Video Control for Instagram",
   "version": "0.6",
 

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Video Control for Instagram",
-  "version": "0.6",
+  "version": "0.7",
 
   "description": "Adds volume and play controls to Instagram videos.",
   "author": "mail@david-schulte.de",


### PR DESCRIPTION
MV3 in Firefox don't enable the script permission for the Instagram site by default. The user would need to manually tick a checkbox deep in the add-on settings. There is no way to request this permission or notify the user to enable it. 

The user will just install the extension, visit Instagram, notice it won't work and uninstall the app with a bad review.

I'll reverted the combined pipeline and use different manifest for Chrome and Firefox again. Firefox is back to MV2. 

This didn't happen when using the debug package for testing. I have no idea how Firefox will sell this feature when the fully migrate to MV3.