### PR TITLE
Fix stories in mobile layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instagram-video-control",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Adds volume and play controls to Instagram videos.",
   "devDependencies": {
     "@types/archiver": "^6.0.2",

--- a/src/videoType.ts
+++ b/src/videoType.ts
@@ -8,6 +8,9 @@ export enum VideoType {
     // The video is in a Story.
     story,
 
+    // The video is in a Story, but in a different, very small layout.
+    mobileStory,
+
     // The video is on the Explore grid.
     explore
 }


### PR DESCRIPTION
When using a small browser window to view Stories, Instagram uses another layout. The reply box is below the video. You can click on the left and right side of the video to move back and forth in the Story. This is only present in mobile view.

Our normal Story modifications won't work. The invisible click-areas overlay the video controls and the user would accidentally move in the Story. Also since we have moved the reply box up, it now overlays our video controls.

This PR fixes all these issues by detecting and treading Stories in mobile layout as its own mode.