### PR TITLE
Temporary fix for muted Reels

### DIFF
--- a/src/ts/instagram/videoDetector.ts
+++ b/src/ts/instagram/videoDetector.ts
@@ -136,7 +136,7 @@ export class VideoDetector implements PlaybackManager {
         this.ignoreNextVolumeChange = true;
         setTimeout(() => {
             this.ignoreNextVolumeChange = false
-        }, 10)
+        }, 50)
 
 
         // Make sure we apply the last used volume settings.


### PR DESCRIPTION
Increase Reels anti-mute delay. Instagram will use a React dispatch routine to apply properties. The mute state is changed later than the play event, but only by a few milliseconds. 10ms was not enough for all cases and lead to muted videos while scrolling. This is just a temporary fix.