### PR TITLE
Fixes hidden controls when the mouse already hovers on initialization

### DIFF
--- a/src/ts/instagram/videoPlayer.ts
+++ b/src/ts/instagram/videoPlayer.ts
@@ -29,6 +29,8 @@ export class VideoPlayer {
         this.createVideoControl();
 
         this.registerEvents();
+
+        this.initHover();
     }
 
     // Detaches the custom player from the video tag. Removes all custom element and events.
@@ -631,6 +633,14 @@ export class VideoPlayer {
     private setHover(hover: boolean) {
         this.hover = hover;
         this.updateControlBarVisibility();
+    }
+
+    // Checks if the mouse already hovers over the video on initialization. Otherwise, the controls would only show up
+    // when the mouse exits and enters again.
+    private initHover() {
+        if (!this.videoRootElement) return;
+        const hover = this.videoRootElement.matches(':hover');
+        this.setHover(hover);
     }
 
     // Changes the visibility of the video controls.


### PR DESCRIPTION
Fix correctly initialized the hover state on player creation. Previously the hover state was only updated when the cursor enters or exists the player area, but not if the cursor was already in the area when the player controls were created.
This prevents the player from noticing the initial hover stat and not showing the controls until the cursor exists and enters again.