### PR TITLE
Fixed time update in custom video player

### DIFF
--- a/src/ts/instagram/controller/customVideoController.ts
+++ b/src/ts/instagram/controller/customVideoController.ts
@@ -154,7 +154,7 @@ export class CustomVideoController extends VideoController {
         this.updatePlayControl();
     }
     public override onTimeUpdate() {
-        this.updatePlayControl();
+        this.updatePositionControl();
     }
     public override onVolumeChange() {
         this.updateVolumeControl();


### PR DESCRIPTION
This PR fixes an issue from the previous code-split: The time controls weren't update in the custom player. This is fixed now.