### PR TITLE
Added `data_collection_permissions` for Firefox

### DIFF
--- a/src/manifest/firefox.json
+++ b/src/manifest/firefox.json
@@ -44,7 +44,11 @@
     "permissions": ["storage"],
     "browser_specific_settings": {
         "gecko": {
-            "id": "{a831defa-a6c9-4ca9-9593-9ccaf98462d9}"
+            "id": "{a831defa-a6c9-4ca9-9593-9ccaf98462d9}",
+            "data_collection_permissions": {
+                "required": [],
+                "optional": []
+            }
         }
     }
 }


### PR DESCRIPTION
Added required `data_collection_permissions` for Firefox. This extension doesn't collect any data, however the field - even if empty - will be required in the future.