### PR TITLE
Added experimental instant detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "instagram-video-control",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "instagram-video-control",
-            "version": "1.7.0",
+            "version": "1.7.1",
             "license": "MIT",
             "devDependencies": {
                 "@types/archiver": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "instagram-video-control",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "Adds volume and play controls to Instagram videos.",
     "devDependencies": {
         "@types/archiver": "^6.0.3",

--- a/src/manifest/chrome.json
+++ b/src/manifest/chrome.json
@@ -43,7 +43,7 @@
     },
     "web_accessible_resources": [
         {
-            "resources": ["images/*.svg", "audio/*.mp3"],
+            "resources": ["images/*.svg", "audio/*.mp3", "js/*.js"],
             "matches": ["https://www.instagram.com/*"]
         }
     ],

--- a/src/manifest/chrome.json
+++ b/src/manifest/chrome.json
@@ -17,6 +17,7 @@
             "matches": ["*://*.instagram.com/*"],
             "js": ["js/instagram.js"],
             "css": ["styles/instagram.css"],
+            "run_at": "document_start",
             "all_frames": true
         }
     ],

--- a/src/manifest/firefox.json
+++ b/src/manifest/firefox.json
@@ -17,6 +17,7 @@
             "matches": ["*://*.instagram.com/*"],
             "js": ["js/instagram.js"],
             "css": ["styles/instagram.css"],
+            "run_at": "document_start",
             "all_frames": true
         }
     ],

--- a/src/manifest/firefox.json
+++ b/src/manifest/firefox.json
@@ -41,7 +41,7 @@
             }
         ]
     },
-    "web_accessible_resources": ["images/*.svg", "audio/*.mp3"],
+    "web_accessible_resources": ["images/*.svg", "audio/*.mp3", "js/*.js"],
     "permissions": ["storage"],
     "browser_specific_settings": {
         "gecko": {

--- a/src/static/_locales/en/messages.json
+++ b/src/static/_locales/en/messages.json
@@ -74,6 +74,27 @@
     "option_loop_playback": {
         "message": "Loop videos"
     },
+    "experimental_settings": {
+        "message": "Experimental settings"
+    },
+    "option_video_detection_method": {
+        "message": "Video detection method"
+    },
+    "option_use_interval_video_detection": {
+        "message": "Delayed (default)"
+    },
+    "option_use_interval_video_detection_description": {
+        "message": "Videos are detected at one second intervals."
+    },
+    "option_use_observer_video_detection": {
+        "message": "Instant (faster, experimental)"
+    },
+    "option_use_observer_video_detection_description": {
+        "message": "Videos are detected instantly when scrolling. This removes the delay before the controls appear, but cost more CPU usage."
+    },
+    "option_warning_reload_required": {
+        "message": "(reload required)"
+    },
     "view_on_github": {
         "message": "View on GitHub"
     },

--- a/src/static/html/popup.html
+++ b/src/static/html/popup.html
@@ -100,7 +100,7 @@
                             ></option>
                         </select>
                     </label>
-                    <div class="hint">
+                    <div class="hint warning">
                         <span
                             data-locale="option_auto_unmute_playback_hint"
                         ></span>
@@ -138,6 +138,41 @@
                         <input type="checkbox" name="option_loop_playback" />
                         <span data-locale="option_loop_playback"></span>
                     </label>
+                </li>
+            </ul>
+
+            <h3 data-locale="experimental_settings"></h3>
+            <ul class="options-list">
+                <li>
+                    <label>
+                        <span
+                            data-locale="option_video_detection_method"
+                        ></span>
+                        <em data-locale="option_warning_reload_required"></em
+                        >:<br />
+                        <select name="option_video_detection_method">
+                            <option
+                                value="interval"
+                                data-locale="option_use_interval_video_detection"
+                            ></option>
+                            <option
+                                value="observer"
+                                data-locale="option_use_observer_video_detection"
+                            ></option>
+                        </select>
+                    </label>
+                    <div class="hint">
+                        <div data-hint="option_use_interval_video_detection">
+                            <span
+                                data-locale="option_use_interval_video_detection_description"
+                            ></span>
+                        </div>
+                        <div data-hint="option_use_observer_video_detection">
+                            <span
+                                data-locale="option_use_observer_video_detection_description"
+                            ></span>
+                        </div>
+                    </div>
                 </li>
             </ul>
         </main>

--- a/src/static/styles/popup.css
+++ b/src/static/styles/popup.css
@@ -58,11 +58,14 @@ ul.options-list li .title {
 }
 
 ul.options-list li .hint {
-    color: #9e7300;
     margin: 0.5em;
     max-width: 400px;
     font-style: italic;
     font-size: 90%;
+}
+
+ul.options-list li .hint.warning {
+    color: #9e7300;
 }
 
 ul.options-list li .hint ul {
@@ -81,7 +84,7 @@ ul.options-list li .hint ul {
         color: #fff;
     }
 
-    ul.options-list li .hint {
+    ul.options-list li .hint.warning {
         color: #ffba00;
     }
 }

--- a/src/ts/instagram/inject.ts
+++ b/src/ts/instagram/inject.ts
@@ -1,0 +1,34 @@
+// This script is injected into the original Instagram DOM. The extension shadow DOM can not see changes made by
+// Instagram itself. This creates an observer that listens for new or removed video elements and tells the extension to
+// run the detection code again.
+// This creates a more responsive result than just scanning for video elements every second.
+// There is more room for optimization, currently we cannot pass the element references into the shadow DOM. An idea is
+// to run the whole extension in the original DOM and create an interface to exchange the extension settings.
+
+const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+        // Detect added video elements
+        for (const addedNode of mutation.addedNodes) {
+            if (!(addedNode instanceof HTMLElement)) continue;
+            const element = addedNode.querySelector('video');
+            if (!element) continue;
+
+            window.postMessage({ type: 'ivcDetectVideos' });
+            return;
+        }
+
+        // Detect removed video elements
+        for (const removedNode of mutation.removedNodes) {
+            if (!(removedNode instanceof HTMLElement)) continue;
+            const element = removedNode.querySelector('video');
+            if (!element) continue;
+
+            window.postMessage({ type: 'ivcDetectVideos' });
+            return;
+        }
+    }
+});
+observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+});

--- a/src/ts/instagram/videoDetector.ts
+++ b/src/ts/instagram/videoDetector.ts
@@ -3,6 +3,7 @@ import { VideoPlayer } from './videoPlayer';
 import { PlaybackManager } from './playbackManager';
 import { Browser } from '../shared/browser';
 import { VideoAutoplayMode } from '../shared/videoAutoplayMode';
+import { VideoDetectionMethod } from '../shared/videoDetectionMethod';
 
 // Detects changes of <video> tags and attaches the custom video players to the Instagram page.
 export class VideoDetector implements PlaybackManager {
@@ -27,17 +28,47 @@ export class VideoDetector implements PlaybackManager {
             this.lastPlaybackMuted = false;
         }
 
-        // Starts the detector.
-        this.start();
+        console.log('videoDetectionMethod', this.settings.videoDetectionMethod);
+        switch (this.settings.videoDetectionMethod) {
+            case VideoDetectionMethod.interval:
+                this.startIntervalDetection();
+                break;
+            case VideoDetectionMethod.observer:
+                this.startMutationObserverDetection();
+                break;
+        }
     }
 
-    // Starts the video detector and adds the control bar.
-    private start() {
+    // Starts the video detector with a fixed time interval.
+    private startIntervalDetection() {
         // Instagram is a single-page-application and loads posts asynchronously. We'll check every second for new videos.
         // MutationObserver is too slow, because there are to many nodes and changes on that site.
         setInterval(() => {
             this.checkForVideosAndAttachControls();
         }, 1000);
+    }
+
+    // Starts the video detection with a MutationObserver.
+    private startMutationObserverDetection() {
+        // Added a JavaScript element to inject code into the original page that
+        // doesn't operate in the shadow DOM and can detect changes all elements
+        // on the page.
+        const scriptElement = document.createElement('script');
+        scriptElement.src = Browser.getUrl('js/inject.js');
+        scriptElement.type = 'module';
+        scriptElement.onload = () => scriptElement.remove();
+        (document.head || document.documentElement).append(scriptElement);
+
+        // Adding the message handler.
+        window.addEventListener('message', (ev) => this.onMessageHandler(ev));
+    }
+
+    // Handling messages from the page.
+    private onMessageHandler(ev: MessageEvent) {
+        // Run video detection
+        if (ev.data.type === 'ivcDetectVideos') {
+            this.checkForVideosAndAttachControls();
+        }
     }
 
     // Checks the page for new or removed video players and attaches / detaches them.
@@ -46,17 +77,7 @@ export class VideoDetector implements PlaybackManager {
 
         // Detect new videos...
         for (let i = 0; i < videos.length; i++) {
-            const video = videos[i];
-            if (this.videosBySource[video.src]) continue;
-
-            const player = new VideoPlayer(this, video);
-            this.videosBySource[video.src] = player;
-
-            player.attach();
-
-            // Update the initial volume and speed.
-            this.updateVolumeForVideo(player.videoElement);
-            this.updatePlaybackSpeedForVideo(player.videoElement);
+            this.detectAddedVideoElement(videos[i]);
         }
 
         // Detect removed videos...
@@ -75,6 +96,27 @@ export class VideoDetector implements PlaybackManager {
 
             delete this.videosBySource[source];
         }
+    }
+
+    public detectAddedVideoElement(video: HTMLVideoElement) {
+        if (this.videosBySource[video.src]) return;
+
+        const player = new VideoPlayer(this, video);
+        this.videosBySource[video.src] = player;
+
+        player.attach();
+
+        // Update the initial volume and speed.
+        this.updateVolumeForVideo(player.videoElement);
+        this.updatePlaybackSpeedForVideo(player.videoElement);
+    }
+
+    public detectRemovedVideoElement(video: HTMLVideoElement) {
+        const player = this.videosBySource[video.src];
+        if (!player) return;
+        player.detach();
+
+        delete this.videosBySource[video.src];
     }
 
     //#region Settings

--- a/src/ts/instagram/videoDetector.ts
+++ b/src/ts/instagram/videoDetector.ts
@@ -28,7 +28,6 @@ export class VideoDetector implements PlaybackManager {
             this.lastPlaybackMuted = false;
         }
 
-        console.log('videoDetectionMethod', this.settings.videoDetectionMethod);
         switch (this.settings.videoDetectionMethod) {
             case VideoDetectionMethod.interval:
                 this.startIntervalDetection();

--- a/src/ts/popup/popup.ts
+++ b/src/ts/popup/popup.ts
@@ -2,6 +2,7 @@ import { Browser } from '../shared/browser';
 import { Settings, SettingsData } from '../shared/settings';
 import { VideoControlMode } from '../shared/videoControlMode';
 import { VideoAutoplayMode } from '../shared/videoAutoplayMode';
+import { VideoDetectionMethod } from '../shared/videoDetectionMethod';
 
 // Code class for the settings menu in the extension icon.
 export class Popup {
@@ -92,7 +93,17 @@ export class Popup {
             (e) => (e.checked = this.settings.loopPlayback)
         );
 
+        // Video detection method
+        this.initSettingSelectElement(
+            'option_video_detection_method',
+            (e) =>
+                (this.settings.videoDetectionMethod =
+                    e.value as VideoDetectionMethod),
+            (e) => (e.value = this.settings.videoDetectionMethod)
+        );
+
         this.updateOptionAutoUnmuteHint();
+        this.updateOptionVideoDetectionMethodHint();
     }
 
     // Handler for setting changes of input elements.
@@ -159,9 +170,16 @@ export class Popup {
 
     // Hide a setting hint.
     private setSettingHintVisibility(name: string, visibility: boolean) {
-        const element = document.querySelector(
+        let element = document.querySelector(
             `li:has([name="${name}"]) .hint`
         ) as HTMLElement;
+
+        if (!element) {
+            element = document.querySelector(
+                `[data-hint="${name}"]`
+            ) as HTMLElement;
+        }
+
         if (!element) return;
         element.style.display = visibility ? 'inherit' : 'none';
     }
@@ -210,6 +228,9 @@ export class Popup {
             case 'autoplayMode':
                 this.updateOptionAutoUnmuteHint();
                 break;
+            case 'videoDetectionMethod':
+                this.updateOptionVideoDetectionMethodHint();
+                break;
         }
     }
 
@@ -217,6 +238,17 @@ export class Popup {
         this.setSettingHintVisibility(
             'option_autoplay_mode',
             this.settings.autoplayMode === VideoAutoplayMode.unmuted
+        );
+    }
+
+    private updateOptionVideoDetectionMethodHint() {
+        this.setSettingHintVisibility(
+            'option_use_interval_video_detection',
+            this.settings.videoDetectionMethod === VideoDetectionMethod.interval
+        );
+        this.setSettingHintVisibility(
+            'option_use_observer_video_detection',
+            this.settings.videoDetectionMethod === VideoDetectionMethod.observer
         );
     }
 

--- a/src/ts/shared/settings.ts
+++ b/src/ts/shared/settings.ts
@@ -5,6 +5,7 @@ import { Utils } from './utils';
 import { VideoAutoplayMode } from './videoAutoplayMode';
 import StorageChangeChrome = chrome.storage.StorageChange;
 import StorageChangeBrowser = browser.storage.StorageChange;
+import { VideoDetectionMethod } from './videoDetectionMethod';
 
 // Settings data struct.
 export interface SettingsData {
@@ -18,6 +19,7 @@ export interface SettingsData {
     showPlaybackSpeedOption: boolean;
     autoHideControlBar: boolean;
     loopPlayback: boolean;
+    videoDetectionMethod: VideoDetectionMethod;
 }
 
 // Handle extension settings.
@@ -38,6 +40,7 @@ export class Settings implements SettingsData {
         'showPlaybackSpeedOption',
         'autoHideControlBar',
         'loopPlayback',
+        'videoDetectionMethod',
     ];
     private _videoControlMode: VideoControlMode = VideoControlMode.custom;
     private _lastPlaybackVolume: number = 0.0;
@@ -49,6 +52,8 @@ export class Settings implements SettingsData {
     private _showPlaybackSpeedOption: boolean = true;
     private _autoHideControlBar: boolean = false;
     private _loopPlayback: boolean = true;
+    private _videoDetectionMethod: VideoDetectionMethod =
+        VideoDetectionMethod.interval;
 
     // The video control mode
     public get videoControlMode(): VideoControlMode {
@@ -160,6 +165,17 @@ export class Settings implements SettingsData {
         this.onChange('loopPlayback');
     }
 
+    // Sets the video detection method.
+    public get videoDetectionMethod(): VideoDetectionMethod {
+        return this._videoDetectionMethod;
+    }
+    public set videoDetectionMethod(value: VideoDetectionMethod) {
+        if (this._videoDetectionMethod === value) return;
+        this._videoDetectionMethod = value;
+
+        this.onChange('videoDetectionMethod');
+    }
+
     //#endregion Data
 
     //#region Init
@@ -248,6 +264,10 @@ export class Settings implements SettingsData {
         }
         if (typeof data.loopPlayback === 'boolean') {
             this.loopPlayback = data.loopPlayback;
+        }
+        if (typeof data.videoDetectionMethod === 'string') {
+            this.videoDetectionMethod =
+                data.videoDetectionMethod as VideoDetectionMethod;
         }
     }
 

--- a/src/ts/shared/videoDetectionMethod.ts
+++ b/src/ts/shared/videoDetectionMethod.ts
@@ -1,0 +1,7 @@
+export enum VideoDetectionMethod {
+    // Videos are detected in a fixed time interval.
+    interval = 'interval',
+
+    // Videos are detected by observing the DOM.
+    observer = 'observer',
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const ESLintPlugin = require('eslint-webpack-plugin');
 module.exports = {
     entry: {
         instagram: './src/ts/instagram/index.ts',
+        inject: './src/ts/instagram/inject.ts',
         popup: './src/ts/popup/index.ts',
     },
     mode: 'development',


### PR DESCRIPTION
This MR adds a new video detection method. Making the controls appear instantly instead of the ~one second delay.
This is done using MutationObserver. This could result in more CPU usage when scrolling, but should reduce usage when idle.

This detection is disabled by default. The detection method can be change via the extension settings.