### PR TITLE
fix for new instagram mute layout

### DIFF
--- a/src/ts/instagram/controller/videoController.ts
+++ b/src/ts/instagram/controller/videoController.ts
@@ -43,6 +43,9 @@ export abstract class VideoController {
     protected adjustVideoControlHeight(controlHeight: number) {
         if (!this.videoPlayer.overlayElement) return;
 
+        // Ensure the overlay stacks above any sibling hitbox divs Instagram may inject at the same level.
+        this.videoPlayer.overlayElement.style.zIndex = '1';
+
         // Removes the height of the controls from the inner overlay to not block mouse clicks.
         if (this.videoPlayer.overlayElement.firstChild instanceof HTMLElement) {
             this.videoPlayer.overlayElement.firstChild.style.height = `calc(100% - ${controlHeight}px)`;
@@ -89,6 +92,11 @@ export abstract class VideoController {
             this.videoPlayer.overlayElement.firstChild instanceof HTMLElement
         ) {
             this.videoPlayer.overlayElement.firstChild.style.height = '';
+        }
+
+        // Restore z-index
+        if (this.videoPlayer.overlayElement) {
+            this.videoPlayer.overlayElement.style.zIndex = '';
         }
 
         // Restore reply controls

--- a/src/ts/instagram/videoPlayer.ts
+++ b/src/ts/instagram/videoPlayer.ts
@@ -289,12 +289,37 @@ export class VideoPlayer {
         // We assume Reels are the default.
         this.videoType = VideoType.reel;
 
-        // The video element is now layered in multiple divs. We traversel upwards until there is a sibling.
+        // Walk up from the <video> looking for a parent that has a direct child with [data-instancekey].
+        // This is robust against Instagram injecting extra sibling elements (e.g. a click-to-mute hitbox div)
+        // between the video wrapper and the player overlay, which broke the old nextElementSibling walk.
         let videoRootElement = this.videoElement as HTMLElement;
-        while (!videoRootElement.nextElementSibling) {
-            const nextElement = videoRootElement.parentElement as HTMLElement;
-            if (!nextElement) break;
-            videoRootElement = nextElement;
+        let overlayFound: HTMLElement | null = null;
+
+        let searchParent = this.videoElement.parentElement as HTMLElement | null;
+        while (searchParent) {
+            const instanceKeyEl = searchParent.querySelector(':scope > [data-instancekey]');
+            if (instanceKeyEl instanceof HTMLElement) {
+                overlayFound = instanceKeyEl;
+                for (const child of searchParent.children) {
+                    if (child instanceof HTMLElement && child !== instanceKeyEl && child.contains(this.videoElement)) {
+                        videoRootElement = child;
+                        break;
+                    }
+                }
+                break;
+            }
+            searchParent = searchParent.parentElement as HTMLElement | null;
+        }
+
+        // Fallback to the original sibling-walk for older DOM layouts.
+        if (!overlayFound) {
+            videoRootElement = this.videoElement as HTMLElement;
+            while (!videoRootElement.nextElementSibling) {
+                const nextElement = videoRootElement.parentElement as HTMLElement;
+                if (!nextElement) break;
+                videoRootElement = nextElement;
+            }
+            overlayFound = videoRootElement.nextElementSibling as HTMLElement;
         }
 
         // It is not easy to detect the video type. We can only guess by checking the node parent chain for clues.
@@ -322,8 +347,7 @@ export class VideoPlayer {
             ) ?? false;
 
         // Detect the native overlay.
-        this.overlayElement =
-            videoRootElement.nextElementSibling as HTMLElement;
+        this.overlayElement = overlayFound ?? undefined;
         this.nativeControlsElement = this.overlayElement
             ?.firstChild as HTMLElement;
 


### PR DESCRIPTION
instagram injected a click-to-mute hitbox div as a sibling between the video wrapper and the data-instancekey overlay div. This caused the old
nextElementSibling walk in detectVideoLatest() to stop at the hitbox
instead of the overlay, so controls were appended to the wrong element

Fix: walk up the DOM searching for a parent with a direct 
child([data-instancekey]) using :scope >, with a fallback to the original sibling-walk for
older layouts. Also set z-index 1 on the overlay element so it stacks
above the hitbox and doesn't block clicks on the extension's controls.

This doesn't hide/interact with the new instagram button
