### PR TITLE
Restore controls for updated Instagram video UI

### DIFF
--- a/src/static/styles/instagram.css
+++ b/src/static/styles/instagram.css
@@ -23,9 +23,18 @@
     background: rgba(38, 38, 38, 0.6);
 }
 
+.ivc-controls.ivc-controls-portal {
+    position: fixed;
+    right: auto;
+    bottom: auto;
+    z-index: 2147483647;
+}
+
 .ivc-controls-content {
     display: flex;
     flex-direction: row;
+
+    pointer-events: auto;
 
     /* Limit the with and center the controls for full screen */
     max-width: 640px;

--- a/src/ts/instagram/controller/customVideoController.test.ts
+++ b/src/ts/instagram/controller/customVideoController.test.ts
@@ -1,0 +1,352 @@
+import { TextDecoder, TextEncoder } from 'util';
+Object.assign(global, { TextDecoder, TextEncoder });
+// This fixes JSDOM
+
+import { describe, expect, jest, test } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+import { CustomVideoController } from './customVideoController';
+
+describe('customVideoController', () => {
+    test('seek bar events do not bubble to Instagram link handlers', () => {
+        const dom = new JSDOM(`
+            <a href="/p/example/">
+                <div id="bar">
+                    <div id="background">
+                        <div id="progress"></div>
+                    </div>
+                </div>
+            </a>
+        `);
+        Object.assign(global, {
+            document: dom.window.document,
+            MouseEvent: dom.window.MouseEvent,
+            TouchEvent: dom.window.TouchEvent,
+        });
+
+        const link = dom.window.document.querySelector('a') as HTMLAnchorElement;
+        const bar = dom.window.document.getElementById('bar') as HTMLElement;
+        const background = dom.window.document.getElementById(
+            'background'
+        ) as HTMLElement;
+        const progress = dom.window.document.getElementById(
+            'progress'
+        ) as HTMLElement;
+        let linkClicks = 0;
+
+        background.getBoundingClientRect = () =>
+            ({
+                left: 0,
+                width: 100,
+            }) as DOMRect;
+        link.addEventListener('click', () => {
+            linkClicks++;
+        });
+
+        (
+            CustomVideoController as unknown as {
+                addDragEventToBar: (
+                    element: HTMLElement,
+                    elementBackground: HTMLElement,
+                    elementProgress: HTMLElement,
+                    invokeOnDrag: boolean,
+                    callback: (value: number) => void
+                ) => void;
+            }
+        ).addDragEventToBar(bar, background, progress, false, () => {});
+
+        bar.dispatchEvent(
+            new dom.window.MouseEvent('click', {
+                bubbles: true,
+                cancelable: true,
+                clientX: 50,
+            })
+        );
+
+        expect(linkClicks).toBe(0);
+    });
+
+    test('seek bar pointer events do not bubble to Instagram link handlers', () => {
+        const dom = new JSDOM(`
+            <a href="/p/example/">
+                <div id="bar">
+                    <div id="background">
+                        <div id="progress"></div>
+                    </div>
+                </div>
+            </a>
+        `);
+        Object.assign(global, {
+            document: dom.window.document,
+            MouseEvent: dom.window.MouseEvent,
+            TouchEvent: dom.window.TouchEvent,
+        });
+
+        const link = dom.window.document.querySelector('a') as HTMLAnchorElement;
+        const bar = dom.window.document.getElementById('bar') as HTMLElement;
+        const background = dom.window.document.getElementById(
+            'background'
+        ) as HTMLElement;
+        const progress = dom.window.document.getElementById(
+            'progress'
+        ) as HTMLElement;
+        let linkPointerDowns = 0;
+
+        background.getBoundingClientRect = () =>
+            ({
+                left: 0,
+                width: 100,
+            }) as DOMRect;
+        link.addEventListener('pointerdown', () => {
+            linkPointerDowns++;
+        });
+
+        (
+            CustomVideoController as unknown as {
+                addDragEventToBar: (
+                    element: HTMLElement,
+                    elementBackground: HTMLElement,
+                    elementProgress: HTMLElement,
+                    invokeOnDrag: boolean,
+                    callback: (value: number) => void
+                ) => void;
+            }
+        ).addDragEventToBar(bar, background, progress, false, () => {});
+
+        bar.dispatchEvent(
+            new dom.window.Event('pointerdown', {
+                bubbles: true,
+                cancelable: true,
+            })
+        );
+
+        expect(linkPointerDowns).toBe(0);
+    });
+
+    test('control event shield does not block seek bar callback', () => {
+        const dom = new JSDOM(`
+            <a href="/p/example/">
+                <div id="content">
+                    <div id="bar">
+                        <div id="background">
+                            <div id="progress"></div>
+                        </div>
+                    </div>
+                </div>
+            </a>
+        `);
+        Object.assign(global, {
+            document: dom.window.document,
+            MouseEvent: dom.window.MouseEvent,
+            TouchEvent: dom.window.TouchEvent,
+        });
+
+        const content = dom.window.document.getElementById(
+            'content'
+        ) as HTMLElement;
+        const bar = dom.window.document.getElementById('bar') as HTMLElement;
+        const background = dom.window.document.getElementById(
+            'background'
+        ) as HTMLElement;
+        const progress = dom.window.document.getElementById(
+            'progress'
+        ) as HTMLElement;
+        const callbackValues: number[] = [];
+
+        background.getBoundingClientRect = () =>
+            ({
+                left: 0,
+                width: 100,
+            }) as DOMRect;
+
+        (
+            CustomVideoController as unknown as {
+                addControlEventShield: (element: HTMLElement) => void;
+                addDragEventToBar: (
+                    element: HTMLElement,
+                    elementBackground: HTMLElement,
+                    elementProgress: HTMLElement,
+                    invokeOnDrag: boolean,
+                    callback: (value: number) => void
+                ) => void;
+            }
+        ).addControlEventShield(content);
+        (
+            CustomVideoController as unknown as {
+                addDragEventToBar: (
+                    element: HTMLElement,
+                    elementBackground: HTMLElement,
+                    elementProgress: HTMLElement,
+                    invokeOnDrag: boolean,
+                    callback: (value: number) => void
+                ) => void;
+            }
+        ).addDragEventToBar(bar, background, progress, false, (value) =>
+            callbackValues.push(value)
+        );
+
+        bar.dispatchEvent(
+            new dom.window.MouseEvent('click', {
+                bubbles: true,
+                cancelable: true,
+                clientX: 50,
+            })
+        );
+
+        expect(callbackValues).toEqual([0.5]);
+    });
+
+    test('document event guard prevents default without blocking seek bar callback', () => {
+        const dom = new JSDOM(`
+            <a href="/p/example/">
+                <div id="content" class="ivc-controls-content">
+                    <div id="bar">
+                        <div id="background">
+                            <div id="progress"></div>
+                        </div>
+                    </div>
+                </div>
+            </a>
+        `);
+        Object.assign(global, {
+            document: dom.window.document,
+            MouseEvent: dom.window.MouseEvent,
+            TouchEvent: dom.window.TouchEvent,
+        });
+
+        const bar = dom.window.document.getElementById('bar') as HTMLElement;
+        const background = dom.window.document.getElementById(
+            'background'
+        ) as HTMLElement;
+        const progress = dom.window.document.getElementById(
+            'progress'
+        ) as HTMLElement;
+        const callbackValues: number[] = [];
+
+        background.getBoundingClientRect = () =>
+            ({
+                left: 0,
+                width: 100,
+            }) as DOMRect;
+
+        (
+            CustomVideoController as unknown as {
+                addDocumentControlEventGuard: () => void;
+                addDragEventToBar: (
+                    element: HTMLElement,
+                    elementBackground: HTMLElement,
+                    elementProgress: HTMLElement,
+                    invokeOnDrag: boolean,
+                    callback: (value: number) => void
+                ) => void;
+            }
+        ).addDocumentControlEventGuard();
+        (
+            CustomVideoController as unknown as {
+                addDragEventToBar: (
+                    element: HTMLElement,
+                    elementBackground: HTMLElement,
+                    elementProgress: HTMLElement,
+                    invokeOnDrag: boolean,
+                    callback: (value: number) => void
+                ) => void;
+            }
+        ).addDragEventToBar(bar, background, progress, false, (value) =>
+            callbackValues.push(value)
+        );
+
+        const event = new dom.window.MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+            clientX: 50,
+        });
+        bar.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(callbackValues).toEqual([0.5]);
+    });
+
+    test('seek helper marks user interaction and seeks when duration is valid', () => {
+        const video = {
+            duration: 20,
+            currentTime: 0,
+            paused: false,
+            dispatchEvent: jest.fn(),
+        } as unknown as HTMLVideoElement;
+        const interactions: string[] = [];
+        const videoPlayer = {
+            setUserInteractedWithVideo: () => interactions.push('seek'),
+        };
+
+        (
+            CustomVideoController as unknown as {
+                seekVideo: (
+                    videoPlayer: { setUserInteractedWithVideo: () => void },
+                    video: HTMLVideoElement,
+                    value: number
+                ) => void;
+            }
+        ).seekVideo(videoPlayer, video, 0.25);
+
+        expect(interactions).toEqual(['seek']);
+        expect(video.currentTime).toBe(5);
+    });
+
+    test('seek helper nudges paused video to decode selected frame', async () => {
+        const pause = jest.fn();
+        const play = jest.fn<() => Promise<void>>().mockResolvedValue();
+        const video = {
+            duration: 20,
+            currentTime: 0,
+            paused: true,
+            play,
+            pause,
+            dispatchEvent: jest.fn(),
+        } as unknown as HTMLVideoElement;
+        const videoPlayer = {
+            setUserInteractedWithVideo: jest.fn(),
+        };
+
+        (
+            CustomVideoController as unknown as {
+                seekVideo: (
+                    videoPlayer: { setUserInteractedWithVideo: () => void },
+                    video: HTMLVideoElement,
+                    value: number
+                ) => void;
+            }
+        ).seekVideo(videoPlayer, video, 0.25);
+
+        await Promise.resolve();
+
+        expect(video.currentTime).toBe(5);
+        expect(play).toHaveBeenCalledTimes(1);
+        expect(pause).toHaveBeenCalledTimes(1);
+    });
+
+    test('seek helper ignores invalid duration', () => {
+        const video = {
+            duration: Number.NaN,
+            currentTime: 3,
+            paused: true,
+            play: jest.fn(),
+            dispatchEvent: jest.fn(),
+        } as unknown as HTMLVideoElement;
+        const interactions: string[] = [];
+        const videoPlayer = {
+            setUserInteractedWithVideo: () => interactions.push('seek'),
+        };
+
+        (
+            CustomVideoController as unknown as {
+                seekVideo: (
+                    videoPlayer: { setUserInteractedWithVideo: () => void },
+                    video: HTMLVideoElement,
+                    value: number
+                ) => void;
+            }
+        ).seekVideo(videoPlayer, video, 0.25);
+
+        expect(interactions).toEqual([]);
+        expect(video.currentTime).toBe(3);
+    });
+});

--- a/src/ts/instagram/controller/customVideoController.ts
+++ b/src/ts/instagram/controller/customVideoController.ts
@@ -26,20 +26,25 @@ export class CustomVideoController extends VideoController {
         0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 2.5, 3.0, 4.0,
     ];
 
+    private static documentControlEventGuardAdded = false;
+
     public create() {
         if (!this.videoPlayer.overlayElement) return;
         const video = this.videoElement;
 
         const controlHeight = 32;
 
-        this.createVideoControlBackground();
+        this.createVideoControlBackground(true);
         this.adjustVideoControlHeight(controlHeight);
 
         // Creating the actual player...
         if (!this.videoControlElement) return;
 
+        CustomVideoController.addDocumentControlEventGuard();
+
         const contentElement = document.createElement('div');
         contentElement.classList.add('ivc-controls-content');
+        CustomVideoController.addControlEventShield(contentElement);
         this.videoControlElement.appendChild(contentElement);
 
         // Play button
@@ -154,7 +159,11 @@ export class CustomVideoController extends VideoController {
             this.seekBarProgressElement,
             /* invokeOnDrag */ false,
             (value) => {
-                video.currentTime = value * video.duration;
+                CustomVideoController.seekVideo(
+                    this.videoPlayer,
+                    video,
+                    value
+                );
             }
         );
 
@@ -259,6 +268,9 @@ export class CustomVideoController extends VideoController {
         this.updatePictureInPictureControl();
         this.updatePlaybackSpeedControl();
         this.updateControlBarVisibility();
+
+        window.addEventListener('scroll', this.onWindowLayoutChange, true);
+        window.addEventListener('resize', this.onWindowLayoutChange);
     }
 
     //#endregion Control
@@ -266,12 +278,15 @@ export class CustomVideoController extends VideoController {
     //#region Events
 
     public override onPlay() {
+        this.updateVideoControlPosition();
         this.updatePlayControl();
     }
     public override onPause() {
+        this.updateVideoControlPosition();
         this.updatePlayControl();
     }
     public override onTimeUpdate() {
+        this.updateVideoControlPosition();
         this.updatePositionControl();
     }
     public override onVolumeChange() {
@@ -287,12 +302,23 @@ export class CustomVideoController extends VideoController {
         this.updatePictureInPictureControl();
     }
     public onUpdateSettings() {
+        this.updateVideoControlPosition();
         this.updatePositionControl();
         this.updateFullscreenControl();
         this.updatePictureInPictureControl();
         this.updatePlaybackSpeedControl();
         this.updateControlBarVisibility();
     }
+
+    public override remove() {
+        window.removeEventListener('scroll', this.onWindowLayoutChange, true);
+        window.removeEventListener('resize', this.onWindowLayoutChange);
+        super.remove();
+    }
+
+    private onWindowLayoutChange = () => {
+        this.updateVideoControlPosition();
+    };
 
     //#endregion Events
 
@@ -442,6 +468,86 @@ export class CustomVideoController extends VideoController {
         img.src = url;
     }
 
+    private static consumeEvent(event: Event) {
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+    }
+
+    private static addDocumentControlEventGuard() {
+        if (CustomVideoController.documentControlEventGuardAdded) return;
+        CustomVideoController.documentControlEventGuardAdded = true;
+
+        const eventNames = [
+            'click',
+            'dblclick',
+            'mousedown',
+            'mouseup',
+            'pointerdown',
+            'pointerup',
+            'pointercancel',
+            'touchstart',
+            'touchend',
+            'touchcancel',
+        ];
+
+        for (const eventName of eventNames) {
+            document.addEventListener(
+                eventName,
+                (event) => {
+                    const target = event.target;
+                    if (!(target instanceof Element)) return;
+                    if (!target.closest('.ivc-controls')) return;
+
+                    event.preventDefault();
+                },
+                true
+            );
+        }
+    }
+
+    private static addControlEventShield(element: HTMLElement) {
+        const eventNames = [
+            'click',
+            'dblclick',
+            'mousedown',
+            'mouseup',
+            'pointerdown',
+            'pointerup',
+            'pointercancel',
+            'touchstart',
+            'touchend',
+            'touchcancel',
+        ];
+
+        for (const eventName of eventNames) {
+            element.addEventListener(
+                eventName,
+                (event) => CustomVideoController.consumeEvent(event),
+                false
+            );
+        }
+    }
+
+    private static seekVideo(
+        videoPlayer: { setUserInteractedWithVideo: () => void },
+        video: HTMLVideoElement,
+        value: number
+    ) {
+        if (!Number.isFinite(video.duration) || video.duration <= 0) return;
+
+        videoPlayer.setUserInteractedWithVideo();
+        video.currentTime = value * video.duration;
+
+        if (video.paused) {
+            video.dispatchEvent(new Event('timeupdate'));
+            video
+                .play()
+                .then(() => video.pause())
+                .catch(() => video.pause());
+        }
+    }
+
     // Handles click and drag events to the bars elements (e.g. seekbar, volume bar).
     private static addDragEventToBar(
         element: HTMLElement,
@@ -452,15 +558,15 @@ export class CustomVideoController extends VideoController {
     ) {
         // Sub function to submit the current bar value
         const onValueChanged = (
-            event: MouseEvent | TouchEvent,
+            event: MouseEvent | TouchEvent | PointerEvent,
             invoke: boolean
         ) => {
             const rect = elementBackground.getBoundingClientRect();
 
             const clientX =
-                event instanceof MouseEvent
-                    ? event.clientX
-                    : event.changedTouches[0].clientX;
+                'changedTouches' in event
+                    ? event.changedTouches[0].clientX
+                    : event.clientX;
             const relativeX = clientX - rect.left;
             const value = Math.max(Math.min(relativeX / rect.width, 1), 0);
 
@@ -472,33 +578,43 @@ export class CustomVideoController extends VideoController {
         // Handle click event
 
         element.addEventListener('click', (event) => {
+            CustomVideoController.consumeEvent(event);
             onValueChanged(event, true);
         });
 
         // Handle drag event
 
         let isDragging = false;
-        const onDragStart = () => {
+        const onDragStart = (
+            event: MouseEvent | TouchEvent | PointerEvent
+        ) => {
+            CustomVideoController.consumeEvent(event);
             isDragging = true;
         };
-        const onDragEnd = (event: MouseEvent | TouchEvent) => {
+        const onDragEnd = (event: MouseEvent | TouchEvent | PointerEvent) => {
             if (!isDragging) return;
+            CustomVideoController.consumeEvent(event);
             onValueChanged(event, true);
             isDragging = false;
         };
-        const onDrag = (event: MouseEvent | TouchEvent) => {
+        const onDrag = (event: MouseEvent | TouchEvent | PointerEvent) => {
             if (!isDragging) return;
+            CustomVideoController.consumeEvent(event);
             onValueChanged(event, invokeOnDrag);
         };
 
         element.addEventListener('mousedown', onDragStart);
         element.addEventListener('touchstart', onDragStart);
+        element.addEventListener('pointerdown', onDragStart);
 
         element.addEventListener('mousemove', onDrag);
         element.addEventListener('touchmove', onDrag);
+        element.addEventListener('pointermove', onDrag);
 
         element.addEventListener('mouseup', onDragEnd);
         element.addEventListener('touchend', onDragEnd);
+        element.addEventListener('pointerup', onDragEnd);
+        element.addEventListener('pointercancel', onDragEnd);
         element.addEventListener('mouseleave', onDragEnd);
     }
 

--- a/src/ts/instagram/controller/videoController.test.ts
+++ b/src/ts/instagram/controller/videoController.test.ts
@@ -1,0 +1,70 @@
+import { TextDecoder, TextEncoder } from 'util';
+Object.assign(global, { TextDecoder, TextEncoder });
+// This fixes JSDOM
+
+import { describe, expect, test } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+import { VideoController } from './videoController';
+import { VideoType } from '../videoType';
+
+class TestVideoController extends VideoController {
+    public createWithPortal(portal: boolean) {
+        this.createVideoControlBackground(portal);
+        return this.videoControlElement;
+    }
+
+    public create() {}
+    public onPlay() {}
+    public onPause() {}
+    public onTimeUpdate() {}
+    public onVolumeChange() {}
+    public onPlaybackSpeedChange() {}
+    public onFullscreenChange() {}
+    public onPictureInPictureChange() {}
+    public onUpdateSettings() {}
+    protected setVisibility() {}
+}
+
+describe('videoController', () => {
+    test('can create controls outside the Instagram overlay subtree', () => {
+        const dom = new JSDOM(`
+            <body>
+                <a id="instagram-link" href="/p/example/">
+                    <div id="overlay"></div>
+                </a>
+                <video></video>
+            </body>
+        `);
+        Object.assign(global, {
+            document: dom.window.document,
+            window: dom.window,
+        });
+
+        const overlay = dom.window.document.getElementById(
+            'overlay'
+        ) as HTMLElement;
+        const video = dom.window.document.querySelector(
+            'video'
+        ) as HTMLVideoElement;
+        const controller = new TestVideoController({
+            overlayElement: overlay,
+            videoElement: video,
+            videoType: VideoType.post,
+        } as never);
+
+        const controls = controller.createWithPortal(true);
+        let parent = controls?.parentElement;
+        let isInsideOverlay = false;
+        while (parent) {
+            if (parent.id === 'overlay') {
+                isInsideOverlay = true;
+                break;
+            }
+            parent = parent.parentElement;
+        }
+
+        expect(controls).toBeDefined();
+        expect(controls?.parentElement?.tagName).toBe('BODY');
+        expect(isInsideOverlay).toBe(false);
+    });
+});

--- a/src/ts/instagram/controller/videoController.ts
+++ b/src/ts/instagram/controller/videoController.ts
@@ -24,19 +24,45 @@ export abstract class VideoController {
     // The main control background element.
     protected videoControlElement: HTMLElement | undefined;
 
+    private videoControlElementIsPortal = false;
+
     // Create the control background.
-    protected createVideoControlBackground() {
+    protected createVideoControlBackground(portal = false) {
         if (!this.videoPlayer.overlayElement) return;
 
+        this.videoControlElementIsPortal = portal;
         this.videoControlElement = document.createElement('div');
         this.videoControlElement.classList.add('ivc-controls');
+        if (portal) {
+            this.videoControlElement.classList.add('ivc-controls-portal');
+        }
         if (this.videoPlayer.videoType === VideoType.reel) {
             this.videoControlElement.classList.add('ivc-reel');
         }
         if (this.videoPlayer.videoType === VideoType.story) {
             this.videoControlElement.classList.add('ivc-story');
         }
-        this.videoPlayer.overlayElement.appendChild(this.videoControlElement);
+        if (portal) {
+            document.body.appendChild(this.videoControlElement);
+            this.updateVideoControlPosition();
+        } else {
+            this.videoPlayer.overlayElement.appendChild(
+                this.videoControlElement
+            );
+        }
+    }
+
+    protected updateVideoControlPosition() {
+        if (!this.videoControlElement || !this.videoControlElementIsPortal) {
+            return;
+        }
+
+        const rect = this.videoElement.getBoundingClientRect();
+        this.videoControlElement.style.left = `${Math.round(rect.left)}px`;
+        this.videoControlElement.style.width = `${Math.round(rect.width)}px`;
+        this.videoControlElement.style.top = `${Math.round(
+            rect.bottom - this.videoControlElement.offsetHeight
+        )}px`;
     }
 
     // Adjust the control bar height for the background and all native elements.

--- a/src/ts/instagram/videoDetector.test.ts
+++ b/src/ts/instagram/videoDetector.test.ts
@@ -52,4 +52,39 @@ describe('videoDetector', () => {
         );
         expect(player.videoType).toBe(VideoType.post);
     });
+
+    test('detect feed video wrapped in media link as Post', async () => {
+        const dom = await JSDOM.fromFile(
+            'tests/data/home-feed-post-link-wrapper.html'
+        );
+        const videoDetector = new VideoDetector();
+        const video = dom.window.document.getElementsByTagName('video')[0];
+        const player = videoDetector.createVideoPlayer(
+            video,
+            VideoDetectionVersion.latest
+        );
+        expect(player.videoType).toBe(VideoType.post);
+    });
+
+    test('detect separate video elements with the same source', () => {
+        const dom = new JSDOM(`
+            <video src="blob:https://www.instagram.com/shared"></video>
+            <video src="blob:https://www.instagram.com/shared"></video>
+        `);
+        Object.assign(global, { document: dom.window.document });
+
+        const videoDetector = new VideoDetector();
+        const attachedVideos: HTMLVideoElement[] = [];
+        videoDetector.createVideoPlayer = (video: HTMLVideoElement) =>
+            ({
+                videoElement: video,
+                attach: () => attachedVideos.push(video),
+            }) as never;
+
+        const videos = dom.window.document.getElementsByTagName('video');
+        videoDetector.detectAddedVideoElement(videos[0]);
+        videoDetector.detectAddedVideoElement(videos[1]);
+
+        expect(attachedVideos).toEqual([videos[0], videos[1]]);
+    });
 });

--- a/src/ts/instagram/videoDetector.ts
+++ b/src/ts/instagram/videoDetector.ts
@@ -12,8 +12,8 @@ export class VideoDetector implements PlaybackManager {
     // The extension settings.
     private readonly settings = Settings.shared;
 
-    // List of all video players by source.
-    private videosBySource: { [source: string]: VideoPlayer } = {};
+    // List of all video players by element.
+    private videosByElement: Map<HTMLVideoElement, VideoPlayer> = new Map();
 
     // Initialize the video detector.
     public async init() {
@@ -82,31 +82,22 @@ export class VideoDetector implements PlaybackManager {
         }
 
         // Detect removed videos...
-        for (const source in this.videosBySource) {
-            let found = false;
-            for (let n = 0; n < videos.length; n++) {
-                if (videos[n].src === source) {
-                    found = true;
-                    break;
-                }
-            }
-            if (found) continue;
+        for (const [videoElement, videoPlayer] of this.videosByElement) {
+            if (Array.prototype.includes.call(videos, videoElement)) continue;
 
-            const video = this.videosBySource[source];
-            video.detach();
-
-            delete this.videosBySource[source];
+            videoPlayer.detach();
+            this.videosByElement.delete(videoElement);
         }
     }
 
     public detectAddedVideoElement(video: HTMLVideoElement) {
-        if (this.videosBySource[video.src]) return;
+        if (this.videosByElement.has(video)) return;
 
         const player = this.createVideoPlayer(
             video,
             Settings.shared.videoDetectionVersion
         );
-        this.videosBySource[video.src] = player;
+        this.videosByElement.set(video, player);
 
         player.attach();
 
@@ -116,11 +107,11 @@ export class VideoDetector implements PlaybackManager {
     }
 
     public detectRemovedVideoElement(video: HTMLVideoElement) {
-        const player = this.videosBySource[video.src];
+        const player = this.videosByElement.get(video);
         if (!player) return;
         player.detach();
 
-        delete this.videosBySource[video.src];
+        this.videosByElement.delete(video);
     }
 
     // Creates the video player from the given HTML video element.
@@ -154,16 +145,14 @@ export class VideoDetector implements PlaybackManager {
 
     // Notify all players that a control setting was changed.
     private updateControlSettingForVideos() {
-        for (const source in this.videosBySource) {
-            const videoPlayer = this.videosBySource[source];
+        for (const videoPlayer of this.videosByElement.values()) {
             videoPlayer.updateControlSetting();
         }
     }
 
     // Notify all players that a control mode was changed.
     private updateControlModeForVideos() {
-        for (const source in this.videosBySource) {
-            const videoPlayer = this.videosBySource[source];
+        for (const videoPlayer of this.videosByElement.values()) {
             videoPlayer.updateControlMode();
         }
     }
@@ -182,8 +171,7 @@ export class VideoDetector implements PlaybackManager {
 
     // Applies the stored volume to all registered videos.
     private updateVolumeForVideos() {
-        for (const source in this.videosBySource) {
-            const videoPlayer = this.videosBySource[source];
+        for (const videoPlayer of this.videosByElement.values()) {
             this.updateVolumeForVideo(videoPlayer.videoElement);
         }
     }
@@ -207,8 +195,7 @@ export class VideoDetector implements PlaybackManager {
 
     // Applies the stored playback speed to all registered videos.
     private updatePlaybackSpeedForVideos() {
-        for (const source in this.videosBySource) {
-            const videoPlayer = this.videosBySource[source];
+        for (const videoPlayer of this.videosByElement.values()) {
             this.updatePlaybackSpeedForVideo(videoPlayer.videoElement);
         }
     }

--- a/src/ts/instagram/videoPlayer.test.ts
+++ b/src/ts/instagram/videoPlayer.test.ts
@@ -1,0 +1,39 @@
+import { TextDecoder, TextEncoder } from 'util';
+Object.assign(global, { TextDecoder, TextEncoder });
+// This fixes JSDOM
+
+import { describe, expect, jest, test } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+import { VideoPlayer } from './videoPlayer';
+import { VideoAutoplayMode } from '../shared/videoAutoplayMode';
+import { Settings } from '../shared/settings';
+
+describe('videoPlayer', () => {
+    test('autoplay disabled resets initial playback but preserves later seek position', () => {
+        const dom = new JSDOM('<video></video>');
+        const video = dom.window.document.querySelector(
+            'video'
+        ) as HTMLVideoElement;
+        const player = new VideoPlayer({} as never, video);
+        const checkAutoplay = (
+            player as unknown as { checkAutoplay: () => void }
+        ).checkAutoplay.bind(player);
+
+        (Settings.shared as unknown as { _autoplayMode: VideoAutoplayMode })
+            ._autoplayMode = VideoAutoplayMode.stopped;
+        video.pause = jest.fn();
+        video.currentTime = 12;
+
+        checkAutoplay();
+
+        expect(video.pause).toHaveBeenCalledTimes(1);
+        expect(video.currentTime).toBe(0);
+
+        video.currentTime = 7;
+
+        checkAutoplay();
+
+        expect(video.pause).toHaveBeenCalledTimes(2);
+        expect(video.currentTime).toBe(7);
+    });
+});

--- a/src/ts/instagram/videoPlayer.ts
+++ b/src/ts/instagram/videoPlayer.ts
@@ -20,6 +20,9 @@ export class VideoPlayer {
     // Has the user already interacted with the video player?
     private userInteractedWithVideo: boolean = false;
 
+    // Has initial unwanted autoplay already been stopped?
+    private autoplayStoppedOnce: boolean = false;
+
     public constructor(
         playbackManager: PlaybackManager,
         videoElement: HTMLVideoElement
@@ -298,6 +301,8 @@ export class VideoPlayer {
         }
 
         // It is not easy to detect the video type. We can only guess by checking the node parent chain for clues.
+        // Current feed posts can wrap the media in an <a>, so scan the complete chain before deciding.
+        let hasAnchorParent = false;
         let currentElement = this.videoElement as HTMLElement;
         while (currentElement) {
             // If we find an <article> tag, we know this is a post in the main feed.
@@ -306,13 +311,16 @@ export class VideoPlayer {
                 break;
             }
 
-            // If we find an <a> tag, we know it must be on the Explore page.
+            // If we find an <a> tag without an article parent, it is a Story-like linked media surface.
             if (currentElement.tagName === 'A') {
-                this.videoType = VideoType.story;
-                break;
+                hasAnchorParent = true;
             }
 
-            currentElement = currentElement.parentNode as HTMLElement;
+            currentElement = currentElement.parentElement as HTMLElement;
+        }
+
+        if (this.videoType !== VideoType.post && hasAnchorParent) {
+            this.videoType = VideoType.story;
         }
 
         // Check for embedded videos.
@@ -582,7 +590,10 @@ export class VideoPlayer {
             !this.userInteractedWithVideo
         ) {
             this.videoElement.pause();
-            this.videoElement.currentTime = 0; // Jump back to start
+            if (!this.autoplayStoppedOnce) {
+                this.videoElement.currentTime = 0; // Jump back to start
+                this.autoplayStoppedOnce = true;
+            }
             this.videoElement.muted = false; // Continue with audio
         }
     }

--- a/tests/data/home-feed-post-link-wrapper.html
+++ b/tests/data/home-feed-post-link-wrapper.html
@@ -1,0 +1,19 @@
+<article>
+    <div>
+        <a href="/p/example/" role="link">
+            <div>
+                <div>
+                    <div>
+                        <video src="blob:https://www.instagram.com/example"></video>
+                    </div>
+                </div>
+                <div data-instancekey="id-vpuid-example">
+                    <div aria-label="Video player" role="group">
+                        <div role="presentation"></div>
+                    </div>
+                </div>
+                <div></div>
+            </div>
+        </a>
+    </div>
+</article>


### PR DESCRIPTION
Spent some time trying to help out here; I used AI to assist.  I hope this is useful and helps move the extension forward.

## Summary

  Restores Instagram video controls after recent UI changes by moving custom controls out of Instagram's clickable media subtree and
  hardening playback interactions.

  ## What changed

  - Render custom controls as a document-level overlay positioned over the video, avoiding Instagram link/modal handlers.
  - Track detected videos by element instead of source so duplicate blob/source values do not suppress controls.
  - Preserve feed-post detection when Instagram wraps media in links.
  - Harden custom control event handling so scrub/volume interactions do not bubble into Instagram handlers.
  - Improve disabled-autoplay behavior so initial autoplay is stopped without undoing later user seeks.
  - Make paused-video scrubbing force frame decode by briefly nudging playback and pausing again.
  - Add regression coverage for event handling, portal placement, duplicate-source detection, feed-link wrapping, autoplay seek
  preservation, and paused seeking.

  ## Validation

  - `npm test -- --runInBand`
  - `npm run compile`
  - Manual Firefox testing:
    - inline custom controls remain usable
    - scrub bar no longer opens Instagram modal
    - paused scrub updates the visible frame
    - autoplay disabled stops initial playback without resetting later seeks
